### PR TITLE
Need to use {} around the environment variables

### DIFF
--- a/redhat/ospfd.service
+++ b/redhat/ospfd.service
@@ -11,7 +11,7 @@ Documentation=man:ospfd
 Type=forking
 EnvironmentFile=/etc/sysconfig/quagga
 ExecStartPre=-/bin/chmod -f 640 /etc/quagga/ospfd.conf
-ExecStartPre=-/bin/chown -f $QUAGGA_USER:$QUAGGA_GROUP /etc/quagga/ospfd.conf
+ExecStartPre=-/bin/chown -f ${QUAGGA_USER}:${QUAGGA_GROUP} /etc/quagga/ospfd.conf
 ExecStart=/usr/sbin/ospfd -d $OSPFD_OPTS -f /etc/quagga/ospfd.conf
 Restart=on-abort
 


### PR DESCRIPTION
Without the `${VARIABLE}` syntax the variables are not properly expanded and `chown`
ends up returning an error:

```
Aug 02 08:01:28 pc.interlinx.bc.ca systemd[1]: Starting OSPF routing daemon...
Aug 02 08:01:28 pc.interlinx.bc.ca chown[11949]: /bin/chown: missing operand after ‘/etc/quagga/ospfd.conf’
Aug 02 08:01:28 pc.interlinx.bc.ca chown[11949]: Try '/bin/chown --help' for more information.
Aug 02 08:01:28 pc.interlinx.bc.ca systemd[1]: Started OSPF routing daemon.
```