### PR TITLE
bgpd: Relax SAFI restrictions on Tunnel Encap attribute

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -3049,7 +3049,10 @@ bgp_packet_attribute (struct bgp *bgp, struct peer *peer,
     }
 
   if ((afi == AFI_IP || afi == AFI_IP6) &&
-      (safi == SAFI_ENCAP || safi == SAFI_MPLS_VPN))
+      (safi == SAFI_UNICAST
+       || safi == SAFI_ENCAP
+       || safi == SAFI_MPLS_VPN
+       || safi == SAFI_MPLS_LABELED_VPN))
     {
 	/* Tunnel Encap attribute */
 	bgp_packet_mpattr_tea(bgp, peer, s, attr, BGP_ATTR_ENCAP);


### PR DESCRIPTION
Allow the BGP Tunnel Encapsulation attribute with AFI/SAFI
1/1 (IPv4 Unicast), 2/1 (IPv6 Unicast), and
1/128 (VPN-IPv4 Labeled Unicast), 2/128 (VPN-IPv6 Labeled Unicast)
as allowed by draft-ietf-idr-tunnel-encaps-10.